### PR TITLE
Adding a github actions that for now executs jest tests

### DIFF
--- a/.github/test_and_build.yml
+++ b/.github/test_and_build.yml
@@ -1,0 +1,36 @@
+name: Test, Build and publish to NPM
+on: 
+  pull_request:
+      branches:
+        - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12"
+
+      # Speed up subsequent runs with caching
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      # Install required deps for action
+      - name: Install Dependencies
+        run: npm install
+
+      # Finally, run our tests
+      - name: Run the tests
+        run: npm test


### PR DESCRIPTION
Adding a github action flow that runs the Jest tests when a PR against main is created.

In the future, if the tests pass and the PR is merged, it should also handle publishing the package to NPM